### PR TITLE
Fix: add raid_level param to netapp_e_volume

### DIFF
--- a/plugins/modules/na_santricity_volume.py
+++ b/plugins/modules/na_santricity_volume.py
@@ -77,7 +77,7 @@ options:
             - Only relevant when the volume is created in a raidDiskPool.
             - I(raid1) in a raidDiskPool is newly introduced in Raider (12.00) CFW.
         type: str
-        choices: ["raid1", "raid6"]
+        choices: ["raid1", "raid5", "raid6"]
         required: false
     thin_provision:
         description:
@@ -334,7 +334,7 @@ class NetAppESeriesVolume(NetAppESeriesModule):
             size_tolerance_b=dict(type="int", required=False, default=10485760),
             segment_size_kb=dict(type="int", default=128, required=False),
             owning_controller=dict(type="str", choices=["A", "B"], required=False),
-            raid_level=dict(type="str", choices=["raid1", "raid6"], required=False),
+            raid_level=dict(type="str", choices=["raid1", "raid5", "raid6"], required=False),
             ssd_cache_enabled=dict(type="bool", default=False),
             data_assurance_enabled=dict(type="bool", default=False),
             thin_provision=dict(type="bool", default=False),


### PR DESCRIPTION
From https://galaxy.ansible.com/ui/repo/published/netapp_eseries/santricity/content/module/netapp_e_volume/?keywords=raid_level 

<img width="1051" height="145" alt="image" src="https://github.com/user-attachments/assets/71cba3f7-b8a6-4c85-8426-006252f642f6" />

That's probably wrong as well, but this PR is about `raid_level` - it's mentioned, but not available in the list of parameters.

```sh
80c80
<         choices: ["raid1", "raid6"]
---
>         choices: ["raid1", "raid5", "raid6"]
337c337
<             raid_level=dict(type="str", choices=["raid1", "raid6"], required=False),
---
>             raid_level=dict(type="str", choices=["raid1", "raid5", "raid6"], required=False),

```
